### PR TITLE
modifying attribute connectivity viz to use bipartitle layout

### DIFF
--- a/pvops/text/visualize.py
+++ b/pvops/text/visualize.py
@@ -2,6 +2,7 @@
 import matplotlib
 import matplotlib.pyplot as plt
 import networkx as nx
+from networkx.algorithms import bipartite
 
 # data structures
 import numpy as np
@@ -29,6 +30,9 @@ def visualize_attribute_connectivity(
 ):
     """Visualize a knowledge graph which shows the frequency of combinations between attributes
     ``ATTRIBUTE1_COL`` and ``ATTRIBUTE2_COL``
+
+    NOW USES BIPARTITE LAYOUT
+    ATTRIBUTE2_COL is colored using a colormap.
 
     Parameters
 
@@ -67,6 +71,9 @@ def visualize_attribute_connectivity(
     ATTRIBUTE1_COL = om_col_dict["attribute1_col"]
     ATTRIBUTE2_COL = om_col_dict["attribute2_col"]
 
+    df = df[df[ATTRIBUTE1_COL].notna()==True].reset_index()
+    df = df[df[ATTRIBUTE2_COL].notna()==True].reset_index()
+
     nx_data = []
     for a in np.unique(df[ATTRIBUTE1_COL].tolist()):
         df_iter = df[df[ATTRIBUTE1_COL] == a]
@@ -77,30 +84,74 @@ def visualize_attribute_connectivity(
     unique_df = pd.DataFrame(
         nx_data, columns=[ATTRIBUTE1_COL, ATTRIBUTE2_COL, "w"])
 
-    G = nx.from_pandas_edgelist(unique_df, ATTRIBUTE1_COL, ATTRIBUTE2_COL, "w")
+    # G = nx.from_pandas_edgelist(unique_df, ATTRIBUTE1_COL, ATTRIBUTE2_COL, "w")
+    M = nx.MultiGraph()
+    M.add_nodes_from(list(set(df[ATTRIBUTE1_COL].tolist())),bipartite=0)
+    M.add_nodes_from(list(set(df[ATTRIBUTE2_COL].tolist())),bipartite=1)
+    edgeList = [(df[ATTRIBUTE1_COL][i],df[ATTRIBUTE2_COL][i]) for i in range(len(df))]
+
+    M.add_edges_from(edgeList)
+
+    G = nx.Graph()
+    G.add_nodes_from(df[ATTRIBUTE1_COL],bipartite=0)
+    G.add_nodes_from(df[ATTRIBUTE2_COL],bipartite=1)
+
+    for u,v,data in M.edges(data=True):
+        w = data['w'] if 'w' in data else 1.0
+        if G.has_edge(u,v):
+            G[u][v]['w'] += w
+        else:
+            G.add_edge(u, v, w=w)
+
+
     fig = plt.figure(figsize=figsize)
     fig.suptitle(
-        f"Connectivity between {ATTRIBUTE1_COL} and {ATTRIBUTE2_COL}",
+        f"Connectivity between {ATTRIBUTE2_COL} and {ATTRIBUTE1_COL}",
         fontsize=50,
-        y=1.08,
+        y=.95,
         fontweight="bold",
     )
 
-    color_map = []
-    for node in G:
-        if node in np.unique(df[ATTRIBUTE2_COL].tolist()):
-            color_map.append(attribute_colors[1])
-        else:
-            color_map.append(attribute_colors[0])
+    # color_map = []
+    # for node in G:
+    #     if node in np.unique(df[ATTRIBUTE2_COL].tolist()):
+    #         color_map.append(attribute_colors[1])
+    #     else:
+    #         color_map.append(attribute_colors[0])
 
     edges = G.edges()
     weights = [G[u][v]["w"] for u, v in edges]
     weights = np.array(weights)
     weights = list(1 + (edge_width_scalar * weights /
                    weights.max()))  # scale 1-11
-    nx.draw_shell(G, width=weights, node_color=color_map, **graph_aargs)
 
-    return fig, edges
+    S = bipartite.projected_graph(G, list(set(df[ATTRIBUTE2_COL].tolist())),multigraph=True)
+    nOrder = [item for sublist in [list(x) for x in nx.community.greedy_modularity_communities(S)] for item in sublist]
+    pos = nx.drawing.layout.bipartite_layout(G,nOrder,align='horizontal')
+
+    cmap = matplotlib.cm.get_cmap('viridis')
+    color_dict = {}
+
+    for i in np.arange(0,(float(len(np.unique(df[ATTRIBUTE2_COL].tolist())))),1.0):
+        color_dict[list(pos.keys())[int(-1*i-1)]]=cmap(i/(float(len(np.unique(df[ATTRIBUTE1_COL].tolist())))-1.0))
+
+
+    color_map = []
+    for node in G:
+        if node in np.unique(df[ATTRIBUTE2_COL].tolist()):
+            color_map.append(attribute_colors[1])
+        else:
+            color_map.append(color_dict[node])
+
+    edge_color_map = []
+    for edge in list(G.edges()):
+        edge_color_map.append(color_dict[edge[0]])
+
+
+    limits = plt.axis("off")
+    nx.draw_networkx(G, width=weights, node_color=color_map, edge_color=edge_color_map, pos=pos, font_weight='bold', **graph_aargs)
+
+    return fig, edges, G
 
 
 def visualize_attribute_timeseries(


### PR DESCRIPTION
## Description

I have modified the function visualize_attribute_connectivity in text/visualize.py. In this version the bipartite layout is used to separate the two classes of attributes. Additionally, the second attribute class given is colored using discrete, uniformly spaced values from the viridis colormap. Edges from these nodes are colored using the same values

## Motivation and Context

The connectivity between two different classes of attribute that this visualization attempts to convey lends itself perfectly to a bipartite layout. The coloring used in the original function helps with this issue, but it is improved greatly by using the bipartite layout. The layout now conveys the separation of the attribute classes, and this separation no longer needs to be conveyed entirely with node color. This opens up the possibility to use coloring to convey yet more detail. We take advantage of this by coloring the attribute nodes of the second class and their associated edges different colors assigned from a colormap. The observer can now get a sense for which class 2 attributes a particular class 1 attribute is connected to, just by looking at the edges connected to it.

## How has this been tested?

I've tested this by creating visualizations with natural gas pipeline notices, and the connectivity between pipeline IDs and notice "type". This was tested in a default Anaconda Python 3.8 environment.

## Screenshots (if appropriate):
<img width="993" alt="Screen Shot 2021-12-17 at 10 28 15 AM" src="https://user-images.githubusercontent.com/57196731/146584382-b2033070-31fd-40db-9c70-b945846a2877.png">
<img width="995" alt="Screen Shot 2021-12-17 at 10 29 01 AM" src="https://user-images.githubusercontent.com/57196731/146584414-eccde25e-a12a-4774-a5c0-30d1307588b1.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!--- Template Acknowledgements: -->
<!--- Template grabbed from https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md -->