### PR TITLE
Correction to requirements.txt file for the readthedocs build process

### DIFF
--- a/docs/pages/requirements.txt
+++ b/docs/pages/requirements.txt
@@ -1,5 +1,0 @@
-ipykernel
-nbsphinx
-nbsphinx-link
-sphinx-copybutton
-sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,9 @@
+ipykernel
+nbsphinx
+nbsphinx-link
+sphinx-copybutton
+sphinx_rtd_theme
+sphinxcontrib.bibtex
+nbformat
+nbconvert
+coverage


### PR DESCRIPTION
# Problem
The documentation build process for readthedocs is [currently failing](https://readthedocs.org/projects/pvops/builds/19286440/). RTD uses a its own`requirements.txt` file, which should be located in the docs/ subdirectory. This got moved around when I was re-organizing the docs file structure, so it was no longer found by RTD.

# Fix
I moved the file back where it belongs and also updated it to contain the new requirements (bibtex extension). This should allow RTD to build the docs successfully.

# Comment
Right now, the github action we have for building the documentation follows a different process than RTD. I think it would be beneficial to change the action to reflect the build process of RTD. That way we can catch these issues before we pull things in and see the docs fail on RTD. I also think that the documentation action only runs once things are pulled in to the master branch. Running the doc build on PRs would also let us catch issues before pulling them in (thus avoiding cleanup PRs like this one and the PR before it).