### PR TITLE
Workflows and linting fixes

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -4,52 +4,41 @@ on: [push, pull_request]
 
 jobs:
   test:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8]
-        requirements: [requirements.txt]
-        include:
-          - requirements: requirements-min.txt
-            python-version: 3.7
-            os: ubuntu-latest
-
-    runs-on: ${{ matrix.os }}
-
+        python-version: ['3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies in ${{ matrix.requirements }}
+    - name: Install pvops
       run: |
         python -m pip install --upgrade pip
-        pip install -r ${{ matrix.requirements }}
+        pip install .
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
         pytest --cov=pvops --cov-config=.coveragerc --cov-report term-missing pvops
 
   lint:
-
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
-
-    runs-on: ubuntu-latest
-
+        python-version: ['3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install flake8
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install flake8
     - name: Lint with flake8
       run: |
-        pip install flake8
         flake8 . --count --statistics --show-source --ignore=E402,E203,E266,E501,W503,F403,F401,E402,W291,E302,W391,W292,F405,E722,W504,E121,E125,E712

--- a/pvops/iv/physics_utils.py
+++ b/pvops/iv/physics_utils.py
@@ -37,7 +37,7 @@ def calculate_IVparams(v, c):
 
     # for snippet_idx in range(len(v[::5])):
     # isc and rsh
-    if type(isc_lim) == float:
+    if isinstance(isc_lim, float):
         isc_size = int(len(c) * isc_lim)
     else:
         isc_size = isc_lim
@@ -47,7 +47,7 @@ def calculate_IVparams(v, c):
     rsh = 1 / (isc_lm.coef_[0][0] * -1)
 
     # voc and rs
-    if type(voc_lim) == float:
+    if isinstance(voc_lim, float):
         voc_size = int(len(v) * voc_lim)
     else:
         voc_size = voc_lim

--- a/pvops/iv/simulator.py
+++ b/pvops/iv/simulator.py
@@ -11,7 +11,7 @@ import random
 from tqdm import tqdm
 import pvlib
 from pvops.iv.utils import get_CEC_params
-from pvops.iv.physics_utils import voltage_pts, add_series, bypass,\
+from pvops.iv.physics_utils import voltage_pts, add_series, bypass, \
     intersection, iv_cutoff, gt_correction
 
 


### PR DESCRIPTION
## Description
This PR updates testing/linting workflows:
- Remove python 3.7 from strategy since it reached EOL
- Added python 3.9 and 3.10 to strategy to track more recent versions in our testing
- Removed the installation of pvops in the linting job since it is unnecessary for the linter to function.

This PR makes minor edits to the code to comply with the latest flake8 rules.