### PR TITLE
Addressing issue 49: Adding links to code in user guide

### DIFF
--- a/docs/pages/moduleguides/iv.rst
+++ b/docs/pages/moduleguides/iv.rst
@@ -8,6 +8,11 @@ Module Overview
 These functions focus on current-voltage (IV) curve simulation and 
 classification.
 
+Examples of usage can be found at:
+  - `tutorial_iv_classifier.ipynb <https://github.com/sandialabs/pvOps/blob/master/examples/tutorial_iv_classifier.ipynb>`_.
+  - `tutorial_iv_diode_extractor.ipynb <https://github.com/sandialabs/pvOps/blob/master/examples/tutorial_iv_diode_extractor.ipynb>`_.
+  - `tutorial_iv_simulator.ipynb <https://github.com/sandialabs/pvOps/blob/master/examples/tutorial_iv_simulator.ipynb>`_.
+
 extractor
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/pages/moduleguides/text.rst
+++ b/docs/pages/moduleguides/text.rst
@@ -18,7 +18,7 @@ to prepare data for natural language processing (text.nlp_utils submodule),
 and a visualization suite (text.visualize submodule).
 
 An example implementation of all capabilities can be found in 
-``text_class_example.py`` for specifics, and `tutorial_textmodule.ipynb` for basics.
+`text_class_example.py <https://github.com/sandialabs/pvOps/blob/master/examples/text_class_example.py>`_ for specifics, and `tutorial_textmodule.ipynb <https://github.com/sandialabs/pvOps/blob/master/examples/tutorial_textmodule.ipynb>`_ for basics.
 
 Text pre-processing
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/pages/moduleguides/text2time.rst
+++ b/docs/pages/moduleguides/text2time.rst
@@ -14,6 +14,10 @@ data fusion. Key features include:
 * generation of baseline values for production loss estimations.
 * calculation of losses from production anomalies for specific time periods.
 
+An example of usage can be found in 
+`tutorial_text2time_module.ipynb <https://github.com/sandialabs/pvOps/blob/master/examples/tutorial_text2time_module.ipynb>`_.
+
+
 The text2time package can be broken down into three main components: 
 `data pre-processing`, `utils`, and `visualizations`.
 

--- a/docs/pages/moduleguides/timeseries.rst
+++ b/docs/pages/moduleguides/timeseries.rst
@@ -16,6 +16,9 @@ Additionally, the ability to generate expected energy via IEC
 standards is implemented in the :py:mod:`~pvops.timeseries.models.iec`
 module.
 
+An example of usage can be found in 
+`tutorial_timeseries_module.ipynb <https://github.com/sandialabs/pvOps/blob/master/examples/tutorial_timeseries_module.ipynb>`.
+
 Preprocess
 ^^^^^^^^^^^^^^^^^^^^^
 * :py:func:`pvops.timeseries.preprocess.prod_inverter_clipping_filter` 

--- a/docs/pages/userguide.rst
+++ b/docs/pages/userguide.rst
@@ -11,16 +11,4 @@ Use these brief guides to get started with their respective module.
     moduleguides/text2time
     moduleguides/timeseries
     moduleguides/iv
-    data
-
-
-
-These guides provide details about specific classes used throughout pvOps.
-
-.. toctree::
-    :maxdepth: 1
-    :caption: Class Guides
-
-    classguides/modcell
-    classguides/ivsimulator
-    classguides/ivclassifier
+    


### PR DESCRIPTION
This PR addresses #49 by adding links to example code where appropriate in the user guide. Additionally, outdated doc pages are removed from the build.