### PR TITLE
[JOSS review] Update tested versions in documentation

### DIFF
--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -1,7 +1,7 @@
 Installation
 =============
 
-pvops is tested on Python version 3.7 and 3.8 and depends on a variety of
+pvops is tested on Python versions 3.8, 3.9, and 3.10 and depends on a variety of
 packages. See :ref:`reqs` for more information.
 
 The latest release of pvops is accessible via PYPI using the following
@@ -18,7 +18,7 @@ Alternatively, the package can be installed using github::
 NLTK data
 ----------
 
-Functions in the text package relies on the "punkt" dataset for the nltk package.
+Functions in the text package rely on the "punkt" dataset from the nltk package.
 After proper installation of pvops, run the commands::
     
     >>> import nltk

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -1,7 +1,7 @@
 Installation
 =============
 
-pvops is tested on Python versions 3.8, 3.9, and 3.10 and depends on a variety of
+pvops is tested on Python versions 3.8, 3.9, 3.10, and 3.11 and depends on a variety of
 packages. See :ref:`reqs` for more information.
 
 The latest release of pvops is accessible via PYPI using the following


### PR DESCRIPTION
The [documentation ](https://pvops.readthedocs.io/en/latest/pages/installation.html) states that the package has been tested on Python 3.7 and 3.8. However, the GitHub test environment runs versions 3.8, 3.9, and 3.10.

https://github.com/sandialabs/pvOps/blob/fe6e6579239ab161908fc5b0d3819b720c161f3c/.github/workflows/lint-and-test.yml#L11

Depending on #57 then 3.11 also needs to be added to the list.

This PR is part of a JOSS review: https://github.com/openjournals/joss-reviews/issues/5755