### PR TITLE
[JOSS review] Rename pvOps examples to tutorials

### DIFF
--- a/docs/pages/examples.rst
+++ b/docs/pages/examples.rst
@@ -1,5 +1,5 @@
-pvOps Examples
-==============
+Tutorials
+=========
 
 Check out the examples below!
 


### PR DESCRIPTION
I suggest renaming _pvOps Examples_  to _Tutorials_

This is merely a small preference.