### PR TITLE
Make IV capabilities optional

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install pvops
       run: |
         python -m pip install --upgrade pip
-        pip install .
+        pip install .[iv]
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - doc
+        - doc, iv

--- a/docs/pages/moduleguides/iv.rst
+++ b/docs/pages/moduleguides/iv.rst
@@ -4,9 +4,13 @@ IV Guide
 Module Overview
 ----------------
 
-
 These functions focus on current-voltage (IV) curve simulation and 
 classification.
+
+.. note::
+  To use the capabilites in this module, pvOps must be installed with the ``iv`` option:
+  ``pip install pvops[iv]``.
+
 
 Tutorials that exemplify usage can be found at:
   - `tutorial_iv_classifier.ipynb <https://github.com/sandialabs/pvOps/blob/master/tutorials/tutorial_iv_classifier.ipynb>`_.

--- a/pvops/__init__.py
+++ b/pvops/__init__.py
@@ -1,7 +1,12 @@
+import warnings
 from pvops import text
 from pvops import text2time
 from pvops import timeseries
-from pvops import iv
+try:
+    from pvops import iv
+except ModuleNotFoundError:
+    # warnings.warn("")
+    pass
 
 __version__ = '0.2.0'
 

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,6 @@ INSTALL_REQUIRES = [
     'pvlib',
     'pvanalytics',
     'timezonefinder',
-    'pyDOE',
-    'tensorflow',
 ]
 
 DOCS_REQUIRE = [
@@ -66,8 +64,14 @@ DOCS_REQUIRE = [
     'sphinx_rtd_theme==1.3.0',
 ]
 
+IV_REQUIRE = [
+    'keras',
+    'tensorflow',
+    'pyDOE',
+]
+
 EXTRAS_REQUIRE = {
-    'optional': ['ruptures'],
+    'iv': IV_REQUIRE,
     'test': TESTS_REQUIRE,
     'doc': DOCS_REQUIRE
 }


### PR DESCRIPTION
## Description
IV related dependencies are moved to an installation extra.

## Motivation and Context
IV capabilities are not used by every user, but come with very bulky dependencies (keras/tensorflow). By making IV optional, these dependencies are not installed by default.

## How has this been tested? Documentation?
Testing workflows have been updated to install iv extra. A note is made in the IV module guide that the extra must be installed to use iv capabilities.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!--- Template Acknowledgements: -->
<!--- Template grabbed from https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md -->