### PR TITLE
Adds missing } in citation

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -172,6 +172,7 @@
   author={Chollet, Fran\c{c}ois and others},
   year={2015},
   howpublished={\url{https://keras.io}}
+}
 
 @article{pedregosa2011sklearn,
   title={Scikit-learn: Machine Learning in {P}ython},


### PR DESCRIPTION
## Description
Small fix to citation for JOSS paper (currently doesn't build)