### PR TITLE
Requiring nltk>=3.9.1; switch punkt to punkt_tab

### DIFF
--- a/pvops/text/preprocess.py
+++ b/pvops/text/preprocess.py
@@ -7,9 +7,9 @@ import traceback
 from datetime import datetime, timedelta
 
 try:
-    nltk.data.find('tokenizers/punkt')
+    nltk.data.find('tokenizers/punkt_tab')
 except LookupError:
-    nltk.download('punkt')
+    nltk.download('punkt_tab')
 
 def preprocessor(
     om_df, lst_stopwords, col_dict, print_info=False, extract_dates_only=False

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas
 numpy
 scipy
 scikit-learn
-nltk
+nltk>=3.9.1
 datefinder
 matplotlib
 seaborn


### PR DESCRIPTION
Previous versions of nltk contained a security vulnerability, discussed in this issue: [https://github.com/nltk/nltk/issues/3266](https://github.com/nltk/nltk/issues/3266). It is strongly recommended to update to version 3.9.1 or higher to resolve the vulnerability. 

Therefore `requirements.txt` is modified to require `nltk>=3.9.1`.

With nltk 3.9.1, `punkt` is deprecated cannot be downloaded using `nltk.download('punkt')`. Instead, `punkt_tab` should be used. The appropriate changes were made to `pvops/text/preprocess.py`.