### PR TITLE
Updating to v4 of actions/artifacts and changing version number

### DIFF
--- a/.github/workflows/builddocs.yml
+++ b/.github/workflows/builddocs.yml
@@ -39,7 +39,7 @@ jobs:
           python -m pip install -e .
       - name: Build documentation
         run: sphinx-build -b html docs/ docs/_build/html
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: html-docs
           path: docs/_build/html

--- a/pvops/__init__.py
+++ b/pvops/__init__.py
@@ -8,7 +8,7 @@ except ModuleNotFoundError:
     # warnings.warn("")
     pass
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 __copyright__ = """Copyright 2023 National Technology & Engineering 
 Solutions of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 


### PR DESCRIPTION
# Problems
After merging agmoore4/inverter-failures into sandialabs/pvOps, two errors were encountered in Actions:
1. docs failed to build because `actions/upload-artifact` v3 is now deprecated.
2. release number was updated in tag but not in `__init__.py`

# Solutions
1. changed `.github/workflows/builddocs.yml` to use `actions/upload-artifact` v4
  a. see https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
  b. the workflow was tested on agmoore4/build-docs-publish and successfully build the docs
2. updated version number to 0.5.0 in `__init__.py`