### PR TITLE
updating version number and what's new section

### DIFF
--- a/docs/pages/releasenotes.rst
+++ b/docs/pages/releasenotes.rst
@@ -5,6 +5,8 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: releasenotes/0.5.3.rst
+
 .. include:: releasenotes/0.5.2.rst
 
 .. include:: releasenotes/0.5.1.rst

--- a/docs/pages/releasenotes/0.5.2.rst
+++ b/docs/pages/releasenotes/0.5.2.rst
@@ -1,4 +1,4 @@
-0.5.1 (February 19 2025)
+0.5.2 (February 21 2025)
 ------------------------
 
 This release updates the documentation to reflect changes starting at v0.4.0 and fixes dependency requirements.

--- a/docs/pages/releasenotes/0.5.3.rst
+++ b/docs/pages/releasenotes/0.5.3.rst
@@ -1,0 +1,17 @@
+0.5.3 (March 5 2025)
+------------------------
+
+This release takes the existing survival analysis tutorial and formalizes parts of it
+into functions within the timeseries module.
+
+Functionality
+~~~~~~~~~~~~~~
+
+* Created a new function in `pvops.timeseries.preprocess` that identifies right-censored data.
+
+* Created a new model under `pvops.timeseries.models` to fit survival analysis functions, namely, Kaplan-Meier and Weibull.
+
+Tutorials
+~~~~~~~~~~~~~~
+
+* Simplified the survival analysis tutorial now that the main functionality is incorporated into pvOps.

--- a/pvops/__init__.py
+++ b/pvops/__init__.py
@@ -8,7 +8,7 @@ except ModuleNotFoundError:
     # warnings.warn("")
     pass
 
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 
 __copyright__ = """Copyright 2023 National Technology & Engineering 
 Solutions of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 


### PR DESCRIPTION
Updates the version number to 0.5.3 and updates the "what's new" section.

Also fixes a mistake in the 0.5.2 what's new section (date and version number were incorrect).