### PR TITLE
updating overview page of docs and 0.6.0 release date on what's new page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ production data, and current-voltage (IV) curves.
      - Production data
      - - estimate expected energy with multiple models
        - evaluate inverter clipping
+       - survival analysis for O&M records
    * - text2time 
      - O&M records and production data 
      - - analyze overlaps between O&M and production (timeseries) records

--- a/docs/pages/releasenotes.rst
+++ b/docs/pages/releasenotes.rst
@@ -5,6 +5,8 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: releasenotes/0.6.1.rst
+
 .. include:: releasenotes/0.6.0.rst
 
 .. include:: releasenotes/0.5.3.rst

--- a/docs/pages/releasenotes/0.6.0.rst
+++ b/docs/pages/releasenotes/0.6.0.rst
@@ -1,4 +1,4 @@
-0.6.0 (March 12 2025)
+0.6.0 (March 17 2025)
 ------------------------
 
 This release removes the `nltk` dependency and implements analogous functionality where needed in pvops.

--- a/docs/pages/releasenotes/0.6.1.rst
+++ b/docs/pages/releasenotes/0.6.1.rst
@@ -1,0 +1,11 @@
+0.6.1 (March 17 2025)
+-----------------------
+
+This release makes minor documentation updates.
+
+Documentation
+~~~~~~~~~~~~~
+
+* The "Overview" page now includes the new survival analysis functionality added to the timeseries module.
+
+* The release date is corrected for version 0.6.0 on the "What's New" page.

--- a/pvops/__init__.py
+++ b/pvops/__init__.py
@@ -8,7 +8,7 @@ except ModuleNotFoundError:
     # warnings.warn("")
     pass
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 __copyright__ = """Copyright 2023 National Technology & Engineering 
 Solutions of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 


### PR DESCRIPTION
Two quick updates to the documentation:
- Adds survival analysis to the description of the timeseries module on the "Overview" page
- Fixes the release date for 0.6.0